### PR TITLE
Updates to remove app secret direct references from ARM template

### DIFF
--- a/ARMTemplates/VivaInsights/SamplePipeline/mainTemplateV1.json
+++ b/ARMTemplates/VivaInsights/SamplePipeline/mainTemplateV1.json
@@ -9,10 +9,10 @@
         "description": "The id of the Azure AD Application that has permission to run the ADF pipeline. This should be a multi tenant application."
       }
     },
-    "AppSecret": {
-      "type": "securestring",
+    "AppObjectId": {
+      "type": "string",
       "metadata": {
-        "description": "The secret for the Azure AD Application. App Secret is required for Microsoft Graph Data Connect (see documentation https://docs.microsoft.com/en-us/graph/data-connect-quickstart?tabs=Microsoft365&tutorial-step=2)."
+        "description": "Object Id of the app registration (this can be found under App registrations -> Select you app -> Click on Managed application in local directory -> Object ID)."
       }
     },
     "AzureActiveDirectoryTenantId": {
@@ -51,30 +51,6 @@
     "adlsSinkKeyVaultLink": "adlsSinkKeyVaultLink"
   },
   "resources": [
-    // Script to get the service principal from an app registration in the Partner subscription.
-    {
-      "apiVersion": "2020-10-01",
-      "kind": "AzurePowerShell",
-      "location": "[resourceGroup().location]",
-      "name": "ApplicationScript",
-      "properties": {
-        "forceUpdateTag": "1",
-        "azPowerShellVersion": "8.0",
-        "environmentVariables": [
-          {
-            "name": "AppSecret",
-            "secureValue": "[parameters('AppSecret')]"
-          }
-        ],
-        "arguments": "[format(' -AppID {0} -TenantId {1} -AppToGet {2}', parameters('AppId'), subscription().tenantId, parameters('AppId'))]",
-        "primaryScriptUri": "https://raw.githubusercontent.com/niblak/dataconnect-solutions/vivaarmtemplates/ARMTemplates/SupportScripts/GetServicePricipalId.ps1",
-        "timeout": "PT30M",
-        "cleanupPreference": "OnSuccess",
-        "retentionInterval": "P1D",
-        "dependsOn": []
-      },
-      "type": "Microsoft.Resources/deploymentScripts"
-    },
     // Storage account in Partner subscription
     {
       "type": "Microsoft.Storage/storageAccounts",
@@ -160,7 +136,7 @@
       "name": "[concat(variables('destinationAdlsAccountName'),'/Microsoft.Authorization/',guid(resourceGroup().id))]",
       "properties": {
         "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-        "principalId": "[reference('ApplicationScript').outputs.PrincipalId]"
+        "principalId": "[parameters('AppObjectId')]"
       }
     },
     // Add Storage Blob Data Contributor role assignment to the Partner storage account container
@@ -173,7 +149,7 @@
       "name": "[concat(variables('destinationAdlsAccountName'), '/default/datasets/Microsoft.Authorization/', guid(concat('blobdatacontributor', resourceGroup().id)))]",
       "properties": {
         "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', 'ba92f5b4-2d11-453d-a403-e96b0029c9fe')]",
-        "principalId": "[reference('ApplicationScript').outputs.PrincipalId]"
+        "principalId": "[parameters('AppObjectId')]"
       }
     },
     // Add Key Vault in the Partner subscription.
@@ -209,7 +185,7 @@
         "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
       ],
       "properties": {
-        "principalId": "[reference('ApplicationScript').outputs.PrincipalId]",
+        "principalId": "[parameters('AppObjectId')]",
         "roleDefinitionId": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '12338af0-0e69-4776-bea7-57ae8d297424')]"
       }
     },
@@ -287,7 +263,6 @@
           },
           "dependsOn": [
             "[resourceId('Microsoft.DataFactory/factories', parameters('DataFactoryName'))]",
-            "[resourceId('Microsoft.Resources/deploymentScripts', 'ApplicationScript')]",
             "[variables('adlsSinkKeyVaultLink')]"
           ]
         },
@@ -388,13 +363,18 @@
               "servicePrincipalTenantId": "[subscription().tenantId]",
               "servicePrincipalId": "[parameters('AppId')]",
               "servicePrincipalKey": {
-                "type": "SecureString",
-                "value": "[parameters('AppSecret')]"
+                "type": "AzureKeyVaultSecret",
+                "store": {
+                  "referenceName": "adlsSinkKeyVaultLink",
+                  "type": "LinkedServiceReference"
+                },
+                "secretName": "DataEgressServicePrincipalKey"
               }
             }
           },
           "dependsOn": [
-            "[resourceId('Microsoft.DataFactory/factories', parameters('DataFactoryName'))]"
+            "[resourceId('Microsoft.DataFactory/factories', parameters('DataFactoryName'))]",
+            "[variables('adlsSinkKeyVaultLink')]"
           ]
         },
         // Define the O365 source dataset to extract by MGDC
@@ -1090,6 +1070,7 @@
             "frequency": "Day",
             "interval": 7,
             "startTime": "2021-10-08T18:04:00Z",
+            "endTime": "2021-10-11T18:04:00Z",
             "timeZone": "UTC",
             "schedule": {}
           }


### PR DESCRIPTION
Removing app secret direct references from ARM template and instead using a KV linked service to get the app secret from the KV.

The ARM template also used the client secret to fetch the service principal id (Object Id) corresponding to the app id. That can be provided as a property now.